### PR TITLE
Use macOS native selection colors.

### DIFF
--- a/themes/Mojave Dark - Blue.alfredappearance
+++ b/themes/Mojave Dark - Blue.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#FCFDFFF2",
         "font" : "System Light",
         "color" : "#FCFDFFF2"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#3F638BE5"
     },
     "window" : {
       "color" : "#323335C4",

--- a/themes/Mojave Dark - Gray.alfredappearance
+++ b/themes/Mojave Dark - Gray.alfredappearance
@@ -10,14 +10,14 @@
       },
       "shortcut" : {
         "size" : 16,
-        "colorSelected" : "#FFFFFFFF",
+        "colorSelected" : "#FFFFFFF2",
         "font" : "System Light",
         "color" : "#FFFFFF6B"
       },
       "backgroundSelected" : "#7F7F7FE5",
       "text" : {
         "size" : 14,
-        "colorSelected" : "#FFFFFFFF",
+        "colorSelected" : "#FFFFFFF2",
         "font" : "System Light",
         "color" : "#F2F2F2FF"
       },
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#FFFFFFF2",
         "font" : "System Light",
         "color" : "#FFFFFFF2"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#6C6C6CE5"
     },
     "window" : {
       "color" : "#353535C4",

--- a/themes/Mojave Dark - Green.alfredappearance
+++ b/themes/Mojave Dark - Green.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#FFFFFFF2",
         "font" : "System Light",
         "color" : "#FCFFFCF2"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#88566EE5"
     },
     "window" : {
       "color" : "#323532C4",

--- a/themes/Mojave Dark - Orange.alfredappearance
+++ b/themes/Mojave Dark - Orange.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#FFFFFFF2",
         "font" : "System Light",
         "color" : "#FFFDFCF2"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#886547E5"
     },
     "window" : {
       "color" : "#353332C4",

--- a/themes/Mojave Dark - Pink.alfredappearance
+++ b/themes/Mojave Dark - Pink.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#FFFFFFF2",
         "font" : "System Light",
         "color" : "#FFFCFDF2"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#88566EE5"
     },
     "window" : {
       "color" : "#353233C4",

--- a/themes/Mojave Dark - Purple.alfredappearance
+++ b/themes/Mojave Dark - Purple.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#FFFFFFF2",
         "font" : "System Light",
         "color" : "#FEFCFFF2"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#705670E5"
     },
     "window" : {
       "color" : "#343235C4",

--- a/themes/Mojave Dark - Red.alfredappearance
+++ b/themes/Mojave Dark - Red.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#FFFFFFF2",
         "font" : "System Light",
         "color" : "#FFFCFCF2"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#8B5758E5"
     },
     "window" : {
       "color" : "#353232C4",

--- a/themes/Mojave Dark - Yellow.alfredappearance
+++ b/themes/Mojave Dark - Yellow.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#FFFFFFF2",
         "font" : "System Light",
         "color" : "#FFFEFCF2"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#8A754AE5"
     },
     "window" : {
       "color" : "#353432C4",

--- a/themes/Mojave Light - Blue.alfredappearance
+++ b/themes/Mojave Light - Blue.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#15202CFF",
         "font" : "System Light",
         "color" : "#15202CFF"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#B3D7FFE5"
     },
     "window" : {
       "color" : "#FCFDFFD6",

--- a/themes/Mojave Light - Gray.alfredappearance
+++ b/themes/Mojave Light - Gray.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#2C2C2CFF",
         "font" : "System Light",
         "color" : "#2C2C2CFF"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#E0E0E0E5"
     },
     "window" : {
       "color" : "#FFFFFFD6",

--- a/themes/Mojave Light - Green.alfredappearance
+++ b/themes/Mojave Light - Green.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#1A2C15FF",
         "font" : "System Light",
         "color" : "#1A2C15FF"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#D0EAC7E5"
     },
     "window" : {
       "color" : "#FCFFFCD6",

--- a/themes/Mojave Light - Orange.alfredappearance
+++ b/themes/Mojave Light - Orange.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#2C1E15FF",
         "font" : "System Light",
         "color" : "#2C1E15FF"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#FCD9BBE5"
     },
     "window" : {
       "color" : "#FFFDFCD6",

--- a/themes/Mojave Light - Pink.alfredappearance
+++ b/themes/Mojave Light - Pink.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#2C151FFF",
         "font" : "System Light",
         "color" : "#2C151FFF"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#FCCAE2E5"
     },
     "window" : {
       "color" : "#FFFCFDD6",

--- a/themes/Mojave Light - Purple.alfredappearance
+++ b/themes/Mojave Light - Purple.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#2B152CFF",
         "font" : "System Light",
         "color" : "#2B152CFF"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#DFC5DFE5"
     },
     "window" : {
       "color" : "#FEFCFFD6",

--- a/themes/Mojave Light - Red.alfredappearance
+++ b/themes/Mojave Light - Red.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#2C1516FF",
         "font" : "System Light",
         "color" : "#2C1516FF"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#F5C3C5E5"
     },
     "window" : {
       "color" : "#FFFCFCD6",

--- a/themes/Mojave Light - Yellow.alfredappearance
+++ b/themes/Mojave Light - Yellow.alfredappearance
@@ -31,11 +31,11 @@
       "spacing" : 6,
       "text" : {
         "size" : 28,
-        "colorSelected" : "#000000FF",
+        "colorSelected" : "#2C2315FF",
         "font" : "System Light",
         "color" : "#2C2315FF"
       },
-      "backgroundSelected" : "#B2D7FFFF"
+      "backgroundSelected" : "#F5C3C5E5"
     },
     "window" : {
       "color" : "#FFFEFCD6",


### PR DESCRIPTION
:wave: Hi there! I'm a big fan of these themes---it's clear that a lot of thought went into making them harmonious with, rather than derivative of, the macOS-native look and feel. The only thing that seemed off was the search selection color, which was consistently set to `#B2D7FF`. (A weird watery blue I assumed came from Bootstrap till I grepped their CSS and learned a Very Special Lesson about prejudice. The More You Know! 🌠)

Anyway, I took a couple minutes and updated the colors to match Mojave's. I also tweaked the color Alfred applies to selected search text so that it matches the color each set of themes uses for unselected text.

###### Before
<img width="605" alt="Screenshot" src="https://user-images.githubusercontent.com/2207980/59603757-3e0ebe00-90d8-11e9-83c5-029cc288d0a7.png">
<img width="605" alt="Screenshot 1" src="https://user-images.githubusercontent.com/2207980/59603763-423adb80-90d8-11e9-9441-12bd6a6a6745.png">

###### After
<img width="605" alt="Screenshot 2" src="https://user-images.githubusercontent.com/2207980/59603770-4666f900-90d8-11e9-8109-aa1360cf4706.png">
<img width="605" alt="Screenshot 3" src="https://user-images.githubusercontent.com/2207980/59603778-48c95300-90d8-11e9-90fe-e0093ab31d94.png">